### PR TITLE
Add RustDoc GitHub Pages Workflow

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,44 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+    release:
+        name: GitHub Pages
+        runs-on: ubuntu-latest
+        permissions:
+          contents: write
+        concurrency:
+          group: ${{ github.workflow }}-${{ github.ref }}
+
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v1
+
+            - name: Install Rust toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                toolchain: stable
+                profile: minimal
+                override: true
+                components: rustfmt, rust-src
+
+            - name: Build Documentation
+              uses: actions-rs/cargo@v1
+              with:
+                command: doc
+                args: --all --no-deps
+
+            - name: Add redirect to project docs index page
+              run: >
+                echo "<meta http-equiv=\"refresh\" content=\"0; url=cec_dpms/index.html\">" > target/doc/index.html
+
+            - name: Deploy
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                publish_dir: ./target/doc
+                destination_dir: docs
+                exclude_assets: '.github,.vscode,target,tests'


### PR DESCRIPTION
First-time setup:

- Go to repo [`branches` page][1] & click "`New Branch`"
  - Name branch: `gh-pages`
- Follow first-time setup steps for the workflow's [First Deployment with `GITHUB_TOKEN`][2]


[1]: https://github.com/trinitronx/cec-dpms/branches
[2]: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token